### PR TITLE
Campaign SB V4 Fix

### DIFF
--- a/lib/blurb/campaign_requests_v4.rb
+++ b/lib/blurb/campaign_requests_v4.rb
@@ -11,7 +11,8 @@ class Blurb
       execute_request(
         api_path: '/list',
         request_type: :post,
-        url_params: url_params
+        url_params: url_params,
+        headers: @headers.merge('Accept' => 'application/vnd.sbcampaignresource.v4+json')
       )
     end
   end


### PR DESCRIPTION
Added missing 'accept' header to list requests in CampaignRequestsV4