### PR TITLE
Amazon Attribution API Support

### DIFF
--- a/lib/blurb/attribution_request.rb
+++ b/lib/blurb/attribution_request.rb
@@ -10,25 +10,8 @@ class Blurb
       @base_url = "#{base_url}/report"
     end
 
-    PERFORMANCE_REPORT_METRICS = %w[
-      Click-throughs
-      attributedDetailPageViewsClicks14d
-      attributedAddToCartClicks14d
-      attributedPurchases14d
-      unitsSold14d
-      attributedSales14d
-      attributedTotalDetailPageViewsClicks14d
-      attributedTotalAddToCartClicks14d
-      attributedTotalPurchases14d
-      totalUnitsSold14d
-      totalAttributedSales14d
-      brb_bonus_amount
-      kindleEditionNormalizedPagesRead14d
-      kindleEditionNormalizedPagesRoyalties14d
-    ].freeze
-
     # https://advertising.amazon.com/API/docs/en-us/amazon-attribution-prod-3p#tag/Reports/operation/getAttributionTagsByCampaign
-    def report(start_date:, end_date:, group_by:, report_type: 'PERFORMANCE', metrics: nil, advertiser_ids: nil, cursor_id: nil, count: 5000) # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
+    def report(start_date:, end_date:, report_type:, group_by:, metrics: nil, advertiser_ids: nil, cursor_id: nil, count: 5000) # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
       execute_request(
         request_type: :post,
         payload: {
@@ -38,7 +21,7 @@ class Blurb
           groupBy: group_by,
           cursorId: cursor_id,
           advertiserIds: advertiser_ids,
-          metrics: metrics || PERFORMANCE_REPORT_METRICS.join(','),
+          metrics: metrics,
           count: count
         }.compact
       )

--- a/lib/blurb/attribution_request.rb
+++ b/lib/blurb/attribution_request.rb
@@ -11,7 +11,7 @@ class Blurb
     end
 
     # https://advertising.amazon.com/API/docs/en-us/amazon-attribution-prod-3p#tag/Reports/operation/getAttributionTagsByCampaign
-    def report(start_date:, end_date:, report_type:, group_by:, metrics: nil, advertiser_ids: nil, cursor_id: nil, count: 5000) # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
+    def report(start_date:, end_date:, report_type:, group_by:, metrics: nil, advertiser_ids: nil, cursor_id: nil, count: 5000) # rubocop:disable Layout/ParameterLists, Metrics/MethodLength, Layout/LineLength
       execute_request(
         request_type: :post,
         payload: {

--- a/lib/blurb/attribution_request.rb
+++ b/lib/blurb/attribution_request.rb
@@ -7,7 +7,7 @@ class Blurb
   class AttributionRequest < RequestCollection
     def initialize(headers:, base_url:, bulk_api_limit: 100)
       super
-      @base_url = "#{base_url}/reports"
+      @base_url = "#{base_url}/report"
     end
 
     PERFORMANCE_REPORT_METRICS = %w[

--- a/lib/blurb/attribution_request.rb
+++ b/lib/blurb/attribution_request.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'blurb/request_collection'
+
+class Blurb
+  # Adapter ADS Attribution API
+  class AttributionRequest < RequestCollection
+    def initialize(headers:, base_url:, bulk_api_limit: 100)
+      super
+      @base_url = "#{base_url}/reports"
+    end
+
+    PERFORMANCE_REPORT_METRICS = %w[
+      Click-throughs
+      attributedDetailPageViewsClicks14d
+      attributedAddToCartClicks14d
+      attributedPurchases14d
+      unitsSold14d
+      attributedSales14d
+      attributedTotalDetailPageViewsClicks14d
+      attributedTotalAddToCartClicks14d
+      attributedTotalPurchases14d
+      totalUnitsSold14d
+      totalAttributedSales14d
+      brb_bonus_amount
+      kindleEditionNormalizedPagesRead14d
+      kindleEditionNormalizedPagesRoyalties14d
+    ].freeze
+
+    # https://advertising.amazon.com/API/docs/en-us/amazon-attribution-prod-3p#tag/Reports/operation/getAttributionTagsByCampaign
+    def report(start_date:, end_date:, group_by:, report_type: 'PERFORMANCE', metrics: nil, advertiser_ids: nil, cursor_id: nil, count: 5000) # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
+      execute_request(
+        request_type: :post,
+        payload: {
+          reportType: report_type,
+          startDate: start_date,
+          endDate: end_date,
+          groupBy: group_by,
+          cursorId: cursor_id,
+          advertiserIds: advertiser_ids,
+          metrics: metrics || PERFORMANCE_REPORT_METRICS.join(','),
+          count: count
+        }.compact
+      )
+    end
+  end
+end

--- a/lib/blurb/profile.rb
+++ b/lib/blurb/profile.rb
@@ -10,6 +10,7 @@ require "blurb/suggested_keyword_requests"
 require "blurb/history_request"
 require "blurb/invoice_request"
 require "blurb/sp_requests"
+require "blurb/attribution_request"
 
 class Blurb
   class Profile < BaseClass
@@ -162,6 +163,10 @@ class Blurb
         headers: headers_hash,
         base_url: "#{@account.api_url}/invoices"
       )
+      @attribution = AttributionRequest.new(
+        headers: headers_hash,
+        base_url: "#{@account.api_url}/attribution"
+      )
     end
 
     def campaigns(campaign_type)
@@ -194,6 +199,10 @@ class Blurb
       return @sp_reports if campaign_type == :sp
       return @sb_reports if campaign_type == :sb || campaign_type == :hsa
       return @sd_reports if campaign_type == :sd
+    end
+
+    def attribution
+      @attribution
     end
 
     def reports_v3


### PR DESCRIPTION
Developments for xapix-io/seller-reporting-sync#2378

Introducing support for Amazon Ads Attribution APIs.

https://advertising.amazon.com/API/docs/en-us/amazon-attribution-prod-3p#tag/Reports/operation/getAttributionTagsByCampaign